### PR TITLE
MAC adress formatted ready for copy&paste

### DIFF
--- a/ESP-Now-Serial-Bridge.ino
+++ b/ESP-Now-Serial-Bridge.ino
@@ -128,6 +128,9 @@ void setup() {
   #ifdef DEBUG
   Serial.print("ESP32 MAC Address: ");
   Serial.println(WiFi.macAddress());
+  String nice_mac = WiFi.macAddress();
+  nice_mac.replace(":", ", 0x");
+  Serial.println("nice_mac: {0x" + nice_mac + "} ");
   #endif
   
   if (esp_wifi_set_channel(WIFI_CHAN, WIFI_SECOND_CHAN_NONE) != ESP_OK) {


### PR DESCRIPTION
Hi @yuri-rage, 
I still love your ESP-Now-Serial-Bridge. 
I added a small string action which allows to transfer the MAC address by Copy and Paste. 
No more typing of MAC addresses.
Maybe you like it.